### PR TITLE
Throw error message instead of the error object itself

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.1.4] - 2018-12-26
+
 ## [0.1.3] - 2018-12-26
 
 ## [0.1.2] - 2018-12-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.1.3] - 2018-12-26
+
 ## [0.1.2] - 2018-12-12
 ### Changed
 - Webpack mode fetched from env

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex-render-session",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Adds session as external to render runtime",
   "scripts": {
     "clean": "rimraf dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex-render-session",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Adds session as external to render runtime",
   "scripts": {
     "clean": "rimraf dist",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ const fetchWithRetry = (url: string, init: RequestInit, maxRetries: number = 3):
           .catch(() => ({ response, error: { message: 'Unable to parse JSON' } }))
     }).then(({ error }: any) => {
       if (error) {
-        throw Error(error)
+        throw Error(error.message)
       }
     }).catch((error) => {
       console.error(error)

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ const fetchWithRetry = (url: string, init: RequestInit, maxRetries: number = 3):
           .catch(() => ({ response, error: { message: 'Unable to parse JSON' } }))
     }).then(({ error }: any) => {
       if (error) {
-        throw Error(error.message)
+        throw new Error(error.message || 'Unknown error')
       }
     }).catch((error) => {
       console.error(error)


### PR DESCRIPTION
As the title says.

The first parameter of the Error object in JS is the error message. Passing an object results in it being converted to a string, resulting in `[Object object]`, which is not very useful, as seen here:

<img width="623" alt="screen shot 2018-12-26 at 10 43 33" src="https://user-images.githubusercontent.com/5691711/50447591-5f4dd900-0903-11e9-93f1-67ca1da1d60e.png">

This PR fixes this issue
