### PR TITLE
No retries on timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.6.0] - 2019-09-25
+
 ## [1.5.0] - 2019-09-25
 ### Changed
 - Add more fields to constants.ts, to get more fields from session.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex-render-session",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Adds session as external to render runtime",
   "scripts": {
     "clean": "rimraf dist",

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,21 +24,39 @@ const supportedLocales = window.__RUNTIME__ && window.__RUNTIME__.culture && win
 const rootPath = window.__RUNTIME__ && window.__RUNTIME__.rootPath || ''
 
 const RETRY_STATUSES = [ 408, 425, 429, 500,  501,  502,  503,  504,  505,  506,  507,  508,  510,  511 ]
+const FETCH_TIMEOUT = 5000
 
 const canRetry = (status: number) => RETRY_STATUSES.includes(status)
 
 const fetchWithRetry = (url: string, init: RequestInit, maxRetries: number = 3) => {
   let status = 500
-  const callFetch = (attempt: number = 0): Promise<SessionResponse>=>
-    fetch(url, init).then((response: Response) => {
+  let didTimeout = false
+  const callFetch = (attempt: number = 0): Promise<SessionResponse> =>
+    new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        didTimeout = true
+        reject(new Error('Fetch timed out'))
+      }, FETCH_TIMEOUT)
+      fetch(url, init).then(response => {
+        clearTimeout(timeout)
+        if (!didTimeout) {
+          resolve(response)
+        }
+      }).catch(err =>  {
+        if (didTimeout) {
+          return
+        }
+        reject(err)
+      })
+    }).then((response: any) => {
       status = response.status
       return response.json()
         .then((data: any) => ({response: data, error: null}))
     }).catch((error) => {
       console.error(error)
 
-      if (attempt >= maxRetries || !canRetry(status)) {
-        return {response: null, error: {message: 'Maximum number of attempts achieved'}} as SessionResponse
+      if (attempt >= maxRetries || !canRetry(status) || didTimeout) {
+        return {response: null, error: {message: 'Maximum number of attempts achieved or request timed out'}} as SessionResponse
       }
 
       const ms = (2 ** attempt) * 500

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ const supportedLocales = window.__RUNTIME__ && window.__RUNTIME__.culture && win
 const rootPath = window.__RUNTIME__ && window.__RUNTIME__.rootPath || ''
 
 const RETRY_STATUSES = [ 408, 425, 429, 500,  501,  502,  503,  504,  505,  506,  507,  508,  510,  511 ]
-const FETCH_TIMEOUT = 5000
+const FETCH_TIMEOUT = 7000
 
 const canRetry = (status: number) => RETRY_STATUSES.includes(status)
 
@@ -43,6 +43,7 @@ const fetchWithRetry = (url: string, init: RequestInit, maxRetries: number = 3) 
           resolve(response)
         }
       }).catch(err =>  {
+        clearTimeout(timeout)
         if (didTimeout) {
           return
         }


### PR DESCRIPTION
Makes session fetch not retry when a timeout of 7 seconds happens.