### PR TITLE
Fix bad session URL when window.location.search changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.8.1] - 2020-04-01
 ### Fixed
 - Fix bad session URL when window.location.search changes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix bad session URL when window.location.search changes.
 
 ## [1.8.0] - 2020-01-13
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex-render-session",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "description": "Adds session as external to render runtime",
   "scripts": {
     "clean": "rimraf dist",

--- a/src/index.ts
+++ b/src/index.ts
@@ -81,8 +81,6 @@ const patchSession = (data?: any) => fetchWithRetry(`${rootPath}/api/sessions${w
   method: 'PATCH',
 }).catch(err => console.log('Error while patching session with error: ', err))
 
-const items = `${window.location.search ? '&' : '?'}items=${ITEMS.join(',')}`
-
 const supportedLocalesSearch = supportedLocales.length > 0
   ? `&supportedLocales=${supportedLocales.join(',')}`
   : ''
@@ -92,6 +90,7 @@ const bindingIdSearch = bindingId
   : ''
 
 const createInitialSessionRequest = () => {
+  const items = `${window.location.search ? '&' : '?'}items=${ITEMS.join(',')}`
   return fetchWithRetry(`${rootPath}/api/sessions${window.location.search}${items}${supportedLocalesSearch}${bindingIdSearch}`, {
     body: '{}',
     credentials: 'same-origin',


### PR DESCRIPTION
The `items` query string is created starting with `?` when there is no `window.location.search`. But, in some cases, before using it to build up the session URL the location is changed to include `?__bindindAddress`. The generated URL end up with two `?`:
```
/api/sessions?__bindingAddress=someAddress?items=account.id,account.accountName,store.channel,store.countryCode,store.cultureInfo,store.currencyCode,store.currencySymbol,store.admin_cultureInfo,creditControl.creditAccounts,creditControl.deadlines,creditControl.minimumInstallmentValue,authentication.storeUserId,authentication.storeUserEmail,profile.firstName,profile.document,profile.email,profile.id,profile.isAuthenticated,profile.lastName,profile.phone,public.favoritePickup,public.utm_source,public.utm_medium,public.utm_campaign,public.utmi_cp,public.utmi_p,public.utmi_pc
```

The query string will work and the response will not include the items requested.