### PR TITLE
Stop prepending '/' root path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Stop prepending '/' rootPath.
 
 ## [1.8.1] - 2020-04-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.8.2] - 2020-05-22
 ### Fixed
 - Stop prepending '/' rootPath.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex-render-session",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "description": "Adds session as external to render runtime",
   "scripts": {
     "clean": "rimraf dist",

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,9 @@ const fetchWithRetry = (url: string, init: RequestInit, maxRetries: number = 3) 
   return callFetch()
 }
 
-const patchSession = (data?: any) => fetchWithRetry(`${rootPath}/api/sessions${window.location.search}`, {
+const rootPathPrefix = rootPath === '/' ? '' : rootPath
+
+const patchSession = (data?: any) => fetchWithRetry(`${rootPathPrefix}/api/sessions${window.location.search}`, {
   body: data ? JSON.stringify(data) : '{}',
   credentials: 'same-origin',
   headers: new Headers({ 'Content-Type': 'application/json' }),
@@ -91,7 +93,7 @@ const bindingIdSearch = bindingId
 
 const createInitialSessionRequest = () => {
   const items = `${window.location.search ? '&' : '?'}items=${ITEMS.join(',')}`
-  return fetchWithRetry(`${rootPath}/api/sessions${window.location.search}${items}${supportedLocalesSearch}${bindingIdSearch}`, {
+  return fetchWithRetry(`${rootPathPrefix}/api/sessions${window.location.search}${items}${supportedLocalesSearch}${bindingIdSearch}`, {
     body: '{}',
     credentials: 'same-origin',
     headers: new Headers({ 'Content-Type': 'application/json' }),
@@ -100,7 +102,7 @@ const createInitialSessionRequest = () => {
 }
 
 const clearSession = () => {
-  return fetchWithRetry(`${rootPath}/api/sessions/invalidToken?items=*`, {
+  return fetchWithRetry(`${rootPathPrefix}/api/sessions/invalidToken?items=*`, {
     credentials: 'same-origin',
     headers: new Headers({ 'Content-Type': 'application/json' }),
     method: 'GET',


### PR DESCRIPTION
It is breaking our session request URL.

> Request URL: https://api/sessions?workspace=master&items=account.id,account.accountName,store.channel,store.countryCode,store.cultureInfo,store.currencyCode,store.currencySymbol,store.admin_cultureInfo,creditControl.creditAccounts,creditControl.deadlines,creditControl.minimumInstallmentValue,authentication.storeUserId,authentication.storeUserEmail,profile.firstName,profile.document,profile.email,profile.id,profile.isAuthenticated,profile.lastName,profile.phone,public.favoritePickup,public.utm_source,public.utm_medium,public.utm_campaign,public.utmi_cp,public.utmi_p,public.utmi_pc&__bindingId=ff7344d2-60fa-4aaa-b342-07d768adfbb9