### PR TITLE
Calls VTEX ID refresh token route before Session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.9.1] - 2020-08-19
+
 ## [1.9.0] - 2020-08-19
 ### Added
 - Calls VTEX ID refresh token route before Sessions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [1.8.2] - 2020-08-12
 ### Added
 - Calls VTEX ID refresh token route before Sessions.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.9.0] - 2020-08-19
 ### Added
 - Calls VTEX ID refresh token route before Sessions.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.8.2] - 2020-08-12
+### Added
+- Calls VTEX ID refresh token route before Sessions.
+
 ## [1.8.1] - 2020-04-01
 ### Fixed
 - Fix bad session URL when window.location.search changes.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex-render-session",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Adds session as external to render runtime",
   "scripts": {
     "clean": "rimraf dist",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex-render-session",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "description": "Adds session as external to render runtime",
   "scripts": {
     "clean": "rimraf dist",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { ITEMS } from './constants'
-import { tryRefreshTokenRenew, tryInsertFirstRenewKey } from './refreshtoken'
+import { tryRefreshTokenRenew, setFirstOrRemoveRenewKey } from './refreshtoken'
 import { SessionResponse } from './interfaces'
 
 const delay = (ms: number): Promise<void> => {
@@ -97,12 +97,12 @@ if (bindingChanged) {
   sessionPromise = tryRefreshTokenRenew()
     .then(clearSession)
     .then(createInitialSessionRequest)
-    .then(tryInsertFirstRenewKey)
+    .then(setFirstOrRemoveRenewKey)
     .catch(onError);
 } else {
   sessionPromise = tryRefreshTokenRenew()
     .then(createInitialSessionRequest)
-    .then(tryInsertFirstRenewKey)
+    .then(setFirstOrRemoveRenewKey)
     .catch(onError);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { ITEMS } from './constants'
+import { renew } from './refreshtoken'
 
 interface SessionResponse {
   response: Response | null,
@@ -110,12 +111,15 @@ const clearSession = () => {
 const onError = (err: any) => console.log('Error while loading session with error: ', err)
 
 let sessionPromise: Promise<void | SessionResponse>
+
 if (bindingChanged) {
-  sessionPromise = clearSession()
+  sessionPromise = renew()
+    .then(clearSession)
     .then(createInitialSessionRequest)
     .catch(onError);
 } else {
-  sessionPromise = createInitialSessionRequest()
+  sessionPromise = renew()
+    .then(createInitialSessionRequest)
     .catch(onError);
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,28 +1,9 @@
 import { ITEMS } from './constants'
-import { renew } from './refreshtoken'
-
-interface SessionResponse {
-  response: Response | null,
-  error: any,
-}
+import { tryRefreshTokenRenew, tryInsertFirstRenewKey } from './refreshtoken'
+import { SessionResponse } from './interfaces'
 
 const delay = (ms: number): Promise<void> => {
   return new Promise(resolve => setTimeout(resolve, ms))
-}
-
-declare global {
-  interface Window {
-    __RUNTIME__: {
-      binding?: {
-        id: string
-      },
-      bindingChanged?: boolean,
-      culture: {
-        availableLocales: string[]
-      }
-      rootPath?: string
-    }
-  }
 }
 
 const bindingChanged = window.__RUNTIME__ && window.__RUNTIME__.bindingChanged
@@ -113,13 +94,15 @@ const onError = (err: any) => console.log('Error while loading session with erro
 let sessionPromise: Promise<void | SessionResponse>
 
 if (bindingChanged) {
-  sessionPromise = renew()
+  sessionPromise = tryRefreshTokenRenew()
     .then(clearSession)
     .then(createInitialSessionRequest)
+    .then(tryInsertFirstRenewKey)
     .catch(onError);
 } else {
-  sessionPromise = renew()
+  sessionPromise = tryRefreshTokenRenew()
     .then(createInitialSessionRequest)
+    .then(tryInsertFirstRenewKey)
     .catch(onError);
 }
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -22,7 +22,7 @@ export interface SessionResponseData {
   namespaces: {
     profile: {
       isAuthenticated: {
-        value: boolean
+        value: string
       }
     }
   }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -1,0 +1,35 @@
+declare global {
+  export interface Window {
+    __RUNTIME__: {
+      binding?: {
+        id: string
+      },
+      bindingChanged?: boolean,
+      culture: {
+        availableLocales: string[]
+      }
+      rootPath?: string
+    }
+  }
+}
+
+export interface SessionResponse {
+  response: SessionResponseData | null,
+  error: any,
+}
+
+export interface SessionResponseData {
+  namespaces: {
+    profile: {
+      isAuthenticated: {
+        value: boolean
+      }
+    }
+  }
+}
+
+export interface RefreshTokenRenewResponse {
+  status: string,
+  userId: string | null,
+  refreshAfter: string | null,
+}

--- a/src/refreshtoken.ts
+++ b/src/refreshtoken.ts
@@ -1,0 +1,86 @@
+interface RefreshTokenRenewResponse {
+  status: string,
+  userId: string | null,
+  refreshAfter: string | null,
+}
+
+const REFRESH_TOKEN_API = '/api/vtexid/refreshtoken/webstore'
+const LOCAL_STORAGE_KEY = 'vid_rt_webstore'
+const STATUS = {
+  SUCCESS: 'success',
+  INVALID_SESSION: 'invalidsession',
+  ERROR: 'error'
+}
+const TTL_30_MIN = 30 * 60 * 1000
+const TTL_12_HOURS = 12 * 60 * 60 * 1000
+const APPNAME = 'render-session'
+const TIMEOUT = 5000
+
+const setItem = (status: string, refreshAfter: Date) =>
+  localStorage.setItem(
+    LOCAL_STORAGE_KEY,
+    JSON.stringify({ status, refreshAfter })
+  )
+
+const setError = () =>
+  setItem(STATUS.ERROR, new Date(new Date().getTime() + TTL_30_MIN))
+
+const setInvalidSession = () =>
+  setItem(STATUS.INVALID_SESSION, new Date(new Date().getTime() + TTL_12_HOURS))
+
+const fetchWithTimeout = (url: string, options: RequestInit | undefined, timeout: number): Promise<Response> => {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => reject(new Error("timeout")), timeout)
+    fetch(url, options).then(resolve, reject)
+  })
+}
+
+export const renew = async () => {
+  const localStorage = window.localStorage
+  if (!window || !localStorage) return
+
+  try {
+    const now = new Date()
+    const item = localStorage.getItem(LOCAL_STORAGE_KEY)
+    if (item) {
+      const curr = JSON.parse(item)
+      if (curr && now < new Date(curr.refreshAfter)) return
+    }
+
+    const curr = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) || 'null')
+    if (curr && now < new Date(curr.refreshAfter)) return
+
+    const response = await fetchWithTimeout(REFRESH_TOKEN_API, {
+      method: 'POST',
+      headers: {
+        'vtex-id-ui-version': APPNAME,
+        'content-type': 'application/json'
+      },
+      body: '{}',
+    }, TIMEOUT)
+
+    const data: RefreshTokenRenewResponse = await response.json();
+
+    if (!data || !data.status) {
+      setError()
+      return
+    }
+
+    const status = data.status.toLowerCase()
+
+    if (status === STATUS.INVALID_SESSION) {
+      setInvalidSession()
+      return
+    }
+
+    if (status === STATUS.SUCCESS) {  
+      const { refreshAfter } = data
+      setItem(status, new Date(refreshAfter as string))
+      return
+    }
+    
+    setError()
+  } catch {
+    setError()
+  }
+}

--- a/src/refreshtoken.ts
+++ b/src/refreshtoken.ts
@@ -41,12 +41,10 @@ export const tryInsertFirstRenewKey = (sessionResponse: SessionResponse) => {
     const isAuthenticated = profile && profile.isAuthenticated.value === "true"
     const keyExists = localStorage.getItem(LOCAL_STORAGE_KEY)
   
-    if (isAuthenticated) {
-      if (!keyExists) {
-        setItem(STATUS.SUCCESS, new Date(new Date().getTime() + TTL_12_HOURS))
-      }
+    if (isAuthenticated && !keyExists) {
+      setItem(STATUS.SUCCESS, new Date(new Date().getTime() + TTL_12_HOURS))
     }
-    else if (keyExists) {
+    if (!isAuthenticated && keyExists) {
       removeKey()
     }
   }

--- a/src/refreshtoken.ts
+++ b/src/refreshtoken.ts
@@ -10,7 +10,7 @@ const STATUS = {
 const TTL_30_MIN = 30 * 60 * 1000
 const TTL_12_HOURS = 12 * 60 * 60 * 1000
 const APPNAME = 'render-session'
-const TIMEOUT = 5000
+const TIMEOUT = 2000
 
 const setItem = (status: string, refreshAfter: Date) =>
   localStorage.setItem(
@@ -37,7 +37,8 @@ export const tryInsertFirstRenewKey = (sessionResponse: SessionResponse) => {
     const localStorage = window.localStorage
     if (!localStorage) return
   
-    const isAuthenticated = (sessionResponse.response as SessionResponseData).namespaces.profile.isAuthenticated.value === "true"
+    const profile = (sessionResponse.response as SessionResponseData).namespaces.profile;
+    const isAuthenticated = profile && profile.isAuthenticated.value === "true"
     const keyExists = localStorage.getItem(LOCAL_STORAGE_KEY)
   
     if (isAuthenticated) {

--- a/src/refreshtoken.ts
+++ b/src/refreshtoken.ts
@@ -32,7 +32,7 @@ const fetchWithTimeout = (url: string, options: RequestInit | undefined, timeout
   })
 }
 
-export const tryInsertFirstRenewKey = (sessionResponse: SessionResponse) => {
+export const setFirstOrRemoveRenewKey = (sessionResponse: SessionResponse) => {
   try {
     const localStorage = window.localStorage
     if (!localStorage) return

--- a/src/refreshtoken.ts
+++ b/src/refreshtoken.ts
@@ -37,7 +37,7 @@ const fetchWithTimeout = (url: string, options: RequestInit | undefined, timeout
 
 export const renew = async () => {
   const localStorage = window.localStorage
-  if (!window || !localStorage) return
+  if (!localStorage) return
 
   try {
     const now = new Date()

--- a/src/refreshtoken.ts
+++ b/src/refreshtoken.ts
@@ -33,21 +33,25 @@ const fetchWithTimeout = (url: string, options: RequestInit | undefined, timeout
 }
 
 export const tryInsertFirstRenewKey = (sessionResponse: SessionResponse) => {
-  const localStorage = window.localStorage
-  if (!localStorage) return
-
-  const isAuthenticated = (sessionResponse.response as SessionResponseData).namespaces.profile.isAuthenticated.value === "true"
-  const keyExists = localStorage.getItem(LOCAL_STORAGE_KEY)
-
-  if (isAuthenticated) {
-    if (!keyExists) {
-      setItem(STATUS.SUCCESS, new Date(new Date().getTime() + TTL_12_HOURS))
+  try {
+    const localStorage = window.localStorage
+    if (!localStorage) return
+  
+    const isAuthenticated = (sessionResponse.response as SessionResponseData).namespaces.profile.isAuthenticated.value === "true"
+    const keyExists = localStorage.getItem(LOCAL_STORAGE_KEY)
+  
+    if (isAuthenticated) {
+      if (!keyExists) {
+        setItem(STATUS.SUCCESS, new Date(new Date().getTime() + TTL_12_HOURS))
+      }
+    }
+    else if (keyExists) {
+      removeKey()
     }
   }
-  else if (keyExists) {
-    removeKey()
+  finally {
+    return sessionResponse
   }
-  return sessionResponse
 }
 
 export const tryRefreshTokenRenew = async () => {

--- a/src/refreshtoken.ts
+++ b/src/refreshtoken.ts
@@ -41,11 +41,6 @@ export const renew = async () => {
 
   try {
     const now = new Date()
-    const item = localStorage.getItem(LOCAL_STORAGE_KEY)
-    if (item) {
-      const curr = JSON.parse(item)
-      if (curr && now < new Date(curr.refreshAfter)) return
-    }
 
     const curr = JSON.parse(localStorage.getItem(LOCAL_STORAGE_KEY) || 'null')
     if (curr && now < new Date(curr.refreshAfter)) return


### PR DESCRIPTION
To make longer login sessions last longer on stores, we are now enabling the refresh token on them.
This PR adds a request to the VTEX ID refresh token route before the request to Session, to renew the authentication token using the refresh token, if possible. It adds the same logic that is already present on admins: uses local storage to save the result of the "renew try" with the time when the next try should be made.