### PR TITLE
Uses rootPath when calling VTEX ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.9.2] - 2020-12-23
 - Uses rootPath when calling VTEX ID
 
 ## [1.9.1] - 2020-08-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Uses rootPath when calling VTEX ID
 
 ## [1.9.1] - 2020-08-19
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vtex-render-session",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "description": "Adds session as external to render runtime",
   "scripts": {
     "clean": "rimraf dist",

--- a/src/refreshtoken.ts
+++ b/src/refreshtoken.ts
@@ -1,6 +1,7 @@
 import { SessionResponse, SessionResponseData, RefreshTokenRenewResponse } from './interfaces'
 
-const REFRESH_TOKEN_API = '/api/vtexid/refreshtoken/webstore'
+const rootPath = window.__RUNTIME__ && window.__RUNTIME__.rootPath || ''
+const REFRESH_TOKEN_API = `${rootPath}/api/vtexid/refreshtoken/webstore`
 const LOCAL_STORAGE_KEY = 'vid_rt_webstore'
 const STATUS = {
   SUCCESS: 'success',


### PR DESCRIPTION
#28 added a call to VTEX ID to refresh the token, but the rootPath wasn't being considered.