### PR TITLE
Feature/add gclid to items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- `gclid` to `ITEMS` constant to support this query string
+- `gclid` to `ITEMS` constant to add the query string to the session
 
 ### Fixed
 - CORS errors during development mode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `gclid` to `ITEMS` constant to support this query string
+
+### Fixed
+- CORS errors during development mode
 
 ## [1.9.2] - 2020-12-23
 - Uses rootPath when calling VTEX ID

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,4 +26,5 @@ export const ITEMS = [
   "public.utmi_cp",
   "public.utmi_p",
   "public.utmi_pc",
+  "public.gclid",
 ];

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,6 +45,9 @@ module.exports = (env, {mode}) => ({
       aggregateTimeout: 300,
       poll: 500,
     },
+    headers: {
+      "Access-Control-Allow-Origin": "*",
+    }
   },
 
   devtool: mode === "production" ? undefined: 'inline-source-map',


### PR DESCRIPTION
## Description

This PR adds `gclid` to the list of query strings that should be included in the session. By doing that, we can access this value on the add-to-cart-button app, where we can send it to the orderForm to then be used by GTM on the orderPlaced page.

This was done so a store's revenue can be linked to Google Adwords adds through `gclid`.

## How to test it

Go to this [workspace](https://icaro--storecomponents.myvtex.com/?gclid=testeidgoogle) and type the following statement on the console after the page is loaded:

```ts
await __RENDER_8_SESSION__.sessionPromise
```

On the `response` object, look for the `namespaces` property. Inside of that, open the `public` object, and then check if there's a `gclid` object there, with value `testeidgoogle`.
